### PR TITLE
Correcting grammar, typos, and other readability issues in the English README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Likely causes:
 - You have not selected `X-MBX-APIKEY` in your Postman `Headers`.
 
 ### Error: `Signature for this request is not valid.`
-These are the likely reasons that can cause this error:
-- Secret key is not set.
-- Parameters are selected, but didn't pass any value. Uncheck the parameter if you don't use it.
+Likely causes:
+- You haven't set your secret key.
+- You've selected parameters for which no value was passed. If you aren't using a parameter, uncheck it.
 
 ### Error: `Mandatory parameter 'xxxx' was not sent, was empty/null, or malformed.`
 - The mandatory parameter is missing. Please refer to the API document and pass all required parameters.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ https://academy.binance.com/economics/binance-api-series-pt-1-spot-trading-with-
 
 ## FAQ
 ### Error: `Could not get any response`
-- Either you haven't setup the environment or the environment is not selected. Please find the step above to setup the environment.
+You haven't imported the environment file, or you've imported it but haven't selected it from the dropdown. Please follow the the steps above to import and select the environment in Postman.
 
 ### Error: `API-key format invalid.`
 - API key is not set.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ We also provide a Postman environment (JSON configuration file), which can be co
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/4.png" alt="Screenshot of Postman for Mac, showing how imported environments can be selected from a dropdown ."/></p>
 
 ## Guide for using the Binance API with Postman
+A guide to using the Binance Spot API Postman Collections can be found here:
 
 https://academy.binance.com/economics/binance-api-series-pt-1-spot-trading-with-postman
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ We also provide a Postman environment (JSON configuration file), which can be co
 
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/1.png"/></p>
    <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/2.png"/></p>
-- Set the API key and secret key. Leave timestamp and signature empty.
-    Please DON'T set into `INTIAL VALUE` column, otherwise postman will upload into your personal postman account. Don't leave `INTIAL VALUE` empty, postman can copy the `CURRENT VALUE` into here.
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/3.png"/></p>
 - Download the Collections.
 - Import the Collections into the Postman app.
@@ -19,6 +17,7 @@ We also provide a Postman environment (JSON configuration file), which can be co
 - Open the Postman app.
 - Click the `Manage Environments` button (gear icon). On Postman for Mac, for example, the button is at the top right of the Postman console:
 - On the `Manage Environments` pop-up page, click `Import`. Select the environment file you downloaded, then click `Add`.
+- Set your API key and secret key. **Please remember** to also set the `Current Value` column (see screenshot); otherwise, Postman will upload into your personal Postman account. (The `Timestamp`, `Signature`, `Initial Value` fields can be left empty. Postman will fill in `Initial Value` with what you provide in `Current Value`.)
     
 - Select the environment from the dropdown.
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/4.png"/></p>

--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ Likely causes:
 
 ### Error: `Mandatory parameter 'xxxx' was not sent, was empty/null, or malformed.`
 
-### How to debug or find out request URL
-- Open Postman console `(CMD/CTRL + ALT + C)`, each request will print request parameters and URL.
-- Edit Pre-request scripts for debugging.
-
 ## Is Postman safe to use
 We suggest users to develop their own application to work with Binance API. However Postman is a good tool for those who want to easily experience APIs. These best pratices are recommended:
 Your request is missing a parameter that the API requires. Please refer to the API documentation, and pass all mandatory parameters in your requests.
@@ -57,6 +53,9 @@ Your request is missing a parameter that the API requires. Please refer to the A
 - Don't use if any code that you don't understand.
 - Make sure that withdrawals are not enabled on your API keys. 
 - Delete API key after use. 
+### How can I debug a request, or find the URL it uses?
+- Open the Postman console `(CMD/CTRL + ALT + C)`. Each request will print out its parameters and URL.
+- To debug, edit your `Pre-request` scripts.
 
 ## My question isn't here
 Please open an issue [here](https://github.com/binance-exchange/binance-api-postman/issues).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ We also provide a Postman environment (JSON configuration file), which can be co
 ## How to import Collections
 
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/1.png"/></p>
-- From the pop-up page, click `import` button, then select the downloaded json file.Click the environment,
    <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/2.png"/></p>
 - Set the API key and secret key. Leave timestamp and signature empty.
     Please DON'T set into `INTIAL VALUE` column, otherwise postman will upload into your personal postman account. Don't leave `INTIAL VALUE` empty, postman can copy the `CURRENT VALUE` into here.
@@ -19,6 +18,7 @@ We also provide a Postman environment (JSON configuration file), which can be co
 - Download the environment JSON file.
 - Open the Postman app.
 - Click the `Manage Environments` button (gear icon). On Postman for Mac, for example, the button is at the top right of the Postman console:
+- On the `Manage Environments` pop-up page, click `Import`. Select the environment file you downloaded, then click `Add`.
     
 - Select the environment from the dropdown.
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/4.png"/></p>

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Likely causes:
 - You've selected parameters for which no value was passed. If you aren't using a parameter, uncheck it.
 
 ### Error: `Mandatory parameter 'xxxx' was not sent, was empty/null, or malformed.`
-- The mandatory parameter is missing. Please refer to the API document and pass all required parameters.
 
 ### How to debug or find out request URL
 - Open Postman console `(CMD/CTRL + ALT + C)`, each request will print request parameters and URL.
@@ -51,6 +50,7 @@ Likely causes:
 
 ## Is Postman safe to use
 We suggest users to develop their own application to work with Binance API. However Postman is a good tool for those who want to easily experience APIs. These best pratices are recommended:
+Your request is missing a parameter that the API requires. Please refer to the API documentation, and pass all mandatory parameters in your requests.
 
 - Don't use collections from distrust channel.
 - Review the json file before using it.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ We also provide a Postman environment (JSON configuration file), which can be co
 
 ## How to import Collections
 
-    
-- Click the button `Manage Environments`(gear icon) from the top right of Postman console (Postman Mac version)
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/1.png"/></p>
 - From the pop-up page, click `import` button, then select the downloaded json file.Click the environment,
    <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/2.png"/></p>
@@ -20,6 +18,7 @@ We also provide a Postman environment (JSON configuration file), which can be co
 ## How to import the environment
 - Download the environment JSON file.
 - Open the Postman app.
+- Click the `Manage Environments` button (gear icon). On Postman for Mac, for example, the button is at the top right of the Postman console:
     
 - Select the environment from the dropdown.
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/4.png"/></p>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ A guide to using the Binance Spot API Postman Collections can be found here:
 
 https://academy.binance.com/economics/binance-api-series-pt-1-spot-trading-with-postman
 
+
+## Postman safety practices
+We suggest that users develop their own applications to work with the Binance Spot API; however, with Postman you can quickly get a feel for each of the API endpoints.
+
+For your safety, please follow these Postman best practices:
+
+- Don't use Collections obtained from an unknown source.
+- Review the environment JSON file before use.
+- Don't use any code that you don't understand.
+- Make sure that the withdrawal permission **is not enabled** for your API keys.
+- When you're finished trying out the API, delete your API keys.
+
+
 ## FAQ
 ### Error: `Could not get any response`
 You haven't imported the environment file, or you've imported it but haven't selected it from the dropdown. Please follow the the steps above to import and select the environment in Postman.
@@ -43,16 +56,8 @@ Likely causes:
 - You've selected parameters for which no value was passed. If you aren't using a parameter, uncheck it.
 
 ### Error: `Mandatory parameter 'xxxx' was not sent, was empty/null, or malformed.`
-
-## Is Postman safe to use
-We suggest users to develop their own application to work with Binance API. However Postman is a good tool for those who want to easily experience APIs. These best pratices are recommended:
 Your request is missing a parameter that the API requires. Please refer to the API documentation, and pass all mandatory parameters in your requests.
 
-- Don't use collections from distrust channel.
-- Review the json file before using it.
-- Don't use if any code that you don't understand.
-- Make sure that withdrawals are not enabled on your API keys. 
-- Delete API key after use. 
 ### How can I debug a request, or find the URL it uses?
 - Open the Postman console `(CMD/CTRL + ALT + C)`. Each request will print out its parameters and URL.
 - To debug, edit your `Pre-request` scripts.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ We also provide a Postman environment (JSON configuration file), which can be co
 
 ## How to import Collections
 
-## How to import environment
-- Download the environment json file
-- Open the postman app
     
 - Click the button `Manage Environments`(gear icon) from the top right of Postman console (Postman Mac version)
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/1.png"/></p>
@@ -20,6 +17,9 @@ We also provide a Postman environment (JSON configuration file), which can be co
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/3.png"/></p>
 - Download the Collections.
 - Import the Collections into the Postman app.
+## How to import the environment
+- Download the environment JSON file.
+- Open the Postman app.
     
 - Select the environment from the dropdown.
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/4.png"/></p>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [Postman](https://getpostman.com) is an API Collaboration Platform.
 
-Binance now has several Postman Collections for quick and easy usage of our REST-based APIs. <br>
-The environment hosted here can be imported for easy changing of API public key, secret key. 
+Binance now offers several Postman Collections for quick and easy usage of our RESTful APIs. <br>
+We also provide a Postman environment (JSON configuration file), which can be conveniently imported for use with your own API and secret keys.
 
 ## How to import collection
 - Download the collections

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ We also provide a Postman environment (JSON configuration file), which can be co
 - On the `Manage Environments` pop-up page, click `Import`. Select the environment file you downloaded, then click `Add`.
 - Set your API key and secret key. **Please remember** to also set the `Current Value` column (see screenshot); otherwise, Postman will upload into your personal Postman account. (The `Timestamp`, `Signature`, `Initial Value` fields can be left empty. Postman will fill in `Initial Value` with what you provide in `Current Value`.)
     
-- Select the environment from the dropdown.
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/4.png"/></p>
+- Select your newly-added environment from the environment dropdown menu. On Mac, this is at top right, to the left of the `Manage Environments` gear icon.
 
 ## Guide for using the Binance API with Postman
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 Binance now offers several Postman Collections for quick and easy usage of our RESTful APIs. <br>
 We also provide a Postman environment (JSON configuration file), which can be conveniently imported for use with your own API and secret keys.
 
-## How to import collection
-- Download the collections
-- Import the collection into Postman APP
+## How to import Collections
 
 ## How to import environment
 - Download the environment json file
@@ -20,6 +18,8 @@ We also provide a Postman environment (JSON configuration file), which can be co
 - Set the API key and secret key. Leave timestamp and signature empty.
     Please DON'T set into `INTIAL VALUE` column, otherwise postman will upload into your personal postman account. Don't leave `INTIAL VALUE` empty, postman can copy the `CURRENT VALUE` into here.
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/3.png"/></p>
+- Download the Collections.
+- Import the Collections into the Postman app.
     
 - Select the environment from the dropdown.
     <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/4.png"/></p>

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ https://academy.binance.com/economics/binance-api-series-pt-1-spot-trading-with-
 You haven't imported the environment file, or you've imported it but haven't selected it from the dropdown. Please follow the the steps above to import and select the environment in Postman.
 
 ### Error: `API-key format invalid.`
-- API key is not set.
-- API key is not correct.
-- In Postman `Headers`, the `X-MBX-APIKEY` is not selected.
+Likely causes:
+- Your API key is not set.
+- Your API key is not correct.
+- You have not selected `X-MBX-APIKEY` in your Postman `Headers`.
 
 ### Error: `Signature for this request is not valid.`
 These are the likely reasons that can cause this error:

--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ We also provide a Postman environment (JSON configuration file), which can be co
 
 ## How to import Collections
 
-    <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/1.png"/></p>
-   <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/2.png"/></p>
-    <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/3.png"/></p>
 - Download the Collections.
 - Import the Collections into the Postman app.
 ## How to import the environment
 - Download the environment JSON file.
 - Open the Postman app.
 - Click the `Manage Environments` button (gear icon). On Postman for Mac, for example, the button is at the top right of the Postman console:
+    <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/1.png" alt="Screenshot of Postman for Mac, with 'Manage Environments' button pointed out at top right."/></p>
 - On the `Manage Environments` pop-up page, click `Import`. Select the environment file you downloaded, then click `Add`.
+   <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/2.png" alt="Screenshot of of Postman for Mac, showing the Manage Environments screen after the Spot API environment file is imported. "/></p>
 - Set your API key and secret key. **Please remember** to also set the `Current Value` column (see screenshot); otherwise, Postman will upload into your personal Postman account. (The `Timestamp`, `Signature`, `Initial Value` fields can be left empty. Postman will fill in `Initial Value` with what you provide in `Current Value`.)
+    <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/3.png" alt="Screenshot of Postman for Mac, showing where the user should fill in their API and secret keys."/></p>
     
-    <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/4.png"/></p>
 - Select your newly-added environment from the environment dropdown menu. On Mac, this is at top right, to the left of the `Manage Environments` gear icon.
+    <p align="center"><img src="https://raw.githubusercontent.com/binance-exchange/binance-api-postman/assets/postman/4.png" alt="Screenshot of Postman for Mac, showing how imported environments can be selected from a dropdown ."/></p>
 
 ## Guide for using the Binance API with Postman
 


### PR DESCRIPTION
This pull request contains improvements which rewrite the project's README into native English. Having found this repo after applying to work at Binance as a Chinese-to-English translator, I realized I could help make the README clearer for English-speaking users.

Apart from numerous changes to spelling, grammar, and punctuation, this PR standardizes the usage of technical terms like JSON, and adds alt-text attributes to the screenshot image tags. In some cases, this PR makes reference to the Chinese README to resolve issues with the English version.