### PR TITLE
fixing toId issues in broker api

### DIFF
--- a/collections/binance_broker_api_v1.postman_collection.json
+++ b/collections/binance_broker_api_v1.postman_collection.json
@@ -640,7 +640,7 @@
 					}
 				],
 				"url": {
-					"raw": "{{url}}/sapi/v1/broker/transfer?fromId=&told=&clientTranId=&asset=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+					"raw": "{{url}}/sapi/v1/broker/transfer?fromId=&toId=&clientTranId=&asset=&amount=&timestamp={{timestamp}}&signature={{signature}}",
 					"host": [
 						"{{url}}"
 					],
@@ -656,7 +656,7 @@
 							"value": ""
 						},
 						{
-							"key": "told",
+							"key": "toId",
 							"value": ""
 						},
 						{


### PR DESCRIPTION
I was facing this error for entire week to understand why I am not able to transfer to sub account, I always used to get **'illegal parameter'** error.

Turns out it was indeed an illegal parameter, because L was used instead of I.