### PR TITLE
Add demo_url variable for COIN-M Futures Postman collection

### DIFF
--- a/collections/Binance Derivatives Trading COIN Futures API.json
+++ b/collections/Binance Derivatives Trading COIN Futures API.json
@@ -4022,6 +4022,11 @@
       "key": "testnet_url",
       "value": "https://testnet.binancefuture.com",
       "type": "string"
+    },
+    {
+      "key": "demo_url",
+      "value": "https://demo-dapi.binance.com",
+      "type": "string"
     }
   ]
 }


### PR DESCRIPTION
This adds the missing collection variable:
•	demo_url: https://demo-dapi.binance.com